### PR TITLE
configures start-windows.bat to detect absolute path

### DIFF
--- a/start-windows.bat
+++ b/start-windows.bat
@@ -9,5 +9,6 @@ set WDS_SOCKET_HOST=localhost
 set WDS_SOCKET_PORT=3000
 set DISABLE_ESLINT_PLUGIN=true
 
-REM Start the application
-node start-dev.js
+REM Start the application after forcing absolute paths to work around sequencer powerup limitation
+SET scriptpath=%~dp0
+start cmd /K "cd %scriptpath:~0,-1% && node start-dev.js"


### PR DESCRIPTION
NINA sequencer power ups has a limitation where the directory of scripts does not pass the command path correctly to subsequent calls. This modification detects & forces the directory in a new CMD fork to ensure that everything loads correctly downstream. Some windows configurations will not need this depending on the CMD autostart configuration. By opening with `start` we also open a separate console to allow various automation to start the service without causing a hang due to expectations of script completion before the next sequencer step.

I found on the PrimaLuceLab Eagle builds this is necessary to make NINA start node successfully as part of Sequencer Powerups. The PLL build is based on Windows 11 IoT.